### PR TITLE
Changed check_multi to ignore immortal characters #13

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -81,7 +81,14 @@ bool	write_to_descriptor(int desc, char* txt, int length);
 bool	check_parse_name(char* name);
 bool	check_reconnect(DESCRIPTOR_DATA* d, char* name, bool fConn);
 bool	check_playing(DESCRIPTOR_DATA* d, char* name, bool kick);
-bool	check_multi(DESCRIPTOR_DATA* d, char* name);
+
+/**
+ * @brief Checks if the user behind the descriptor already has a character playing on another descriptor.
+ * @param new_descriptor Descriptor to check.
+ * @param name Name of the character for the descriptor.
+ * @return TRUE if the user is already playing on another descriptor, FALSE otherwise.
+*/
+bool	check_multi(DESCRIPTOR_DATA* new_descriptor, char* name);
 int	main(int argc, char** argv);
 void	nanny(DESCRIPTOR_DATA* d, char* argument);
 bool	flush_buffer(DESCRIPTOR_DATA* d, bool fPrompt);
@@ -2164,47 +2171,41 @@ bool check_reconnect(DESCRIPTOR_DATA* d, char* name, bool fConn)
     return FALSE;
 }
 
-
-
-/*
- * Check if already playing.
- */
-
-bool check_multi(DESCRIPTOR_DATA* d, char* name)
+bool check_multi(DESCRIPTOR_DATA* new_descriptor, char* name)
 {
-    DESCRIPTOR_DATA* dold;
+    DESCRIPTOR_DATA* old_descriptor;
+    CHAR_DATA* old_character;
 
-    for (dold = first_descriptor; dold; dold = dold->next)
+    for (old_descriptor = first_descriptor; old_descriptor; old_descriptor = old_descriptor->next)
     {
-        if (dold != d
-            && (dold->character || dold->original)
-            && str_cmp(name, dold->original
-                       ? dold->original->name : dold->character->name)
-            && !str_cmp(dold->host, d->host))
+        if (old_descriptor == new_descriptor)
         {
-            const char* ok = "194.234.177";
-            const char* ok2 = "209.183.133.229";
-            int iloop;
+            continue;
+        }
 
-            for (iloop = 0; iloop < 11; iloop++)
-            {
-                if (ok[iloop] != d->host[iloop])
-                    break;
-            }
-            if (iloop >= 10)
-                return FALSE;
-            for (iloop = 0; iloop < 11; iloop++)
-            {
-                if (ok2[iloop] != d->host[iloop])
-                    break;
-            }
-            if (iloop >= 10)
-                return FALSE;
-            write_to_buffer(d, "Sorry multi-playing is not allowed ... have you other character quit first.\n\r", 0);
-            sprintf(log_buf, "%s attempting to multiplay with %s.", dold->original ? dold->original->name : dold->character->name, d->character->name);
+        old_character = old_descriptor->original != NULL ? old_descriptor->original : old_descriptor->character;
+
+        if (old_character == NULL)
+        {
+            continue;
+        }
+
+        if (IS_IMMORTAL(old_character))
+        {
+            continue;
+        }
+
+        // Checking the name lets you login with a different client and kick off the
+        // old connection.
+        if (str_cmp(name, old_character->name)
+            && !str_cmp(old_descriptor->host, new_descriptor->host))
+        {
+            write_to_buffer(new_descriptor, "Sorry multi-playing is not allowed ... have you other character quit first.\n\r", 0);
+            sprintf(log_buf, "%s attempting to multiplay with %s.", old_character->name, new_descriptor->character->name);
             log_string_plus(log_buf, LOG_COMM);
-            d->character = NULL;
-            free_char(d->character);
+            new_descriptor->character = NULL;
+            free_char(new_descriptor->character);
+
             return TRUE;
         }
     }

--- a/src/db.c
+++ b/src/db.c
@@ -2714,13 +2714,6 @@ char* show_tilde(char* str)
     return buf;
 }
 
-
-
-/*
- * Compare strings, case insensitive.
- * Return TRUE if different
- *   (compatibility with historical functions).
- */
 bool str_cmp(const char* astr, const char* bstr)
 {
     if (!astr)

--- a/src/mud.h
+++ b/src/mud.h
@@ -3489,6 +3489,13 @@ int	interpolate(int level, int value_00, int value_32);
 void	smash_tilde(char* str);
 void	hide_tilde(char* str);
 char* show_tilde(char* str);
+
+/**
+ * @brief Case insensitive comparison of strings to determine if they are different.
+ * @param astr First string to compare.
+ * @param bstr Second string to compare to the first string.
+ * @returns TRUE if different, FALSE if the same.
+ */
 bool	str_cmp(const char* astr, const char* bstr);
 bool	str_prefix(const char* astr, const char* bstr);
 bool	str_infix(const char* astr, const char* bstr);


### PR DESCRIPTION
Resolves #13.

Changed check_multi to ignore descriptors with immortal characters. Did some refactoring and documentation.